### PR TITLE
Add test starting pod with bridge as requested resource

### DIFF
--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -15,19 +15,26 @@
 package tests_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/kubevirt/bridge-marker/tests"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DefaultNamespace = "default"
 )
 
 var _ = Describe("bridge-marker", func() {
 	Describe("bridge resource reporting", func() {
 		It("should be reported only when available on node", func() {
-			resourceName := tests.GenerateResourceName()
+			resourceName := tests.GenerateResourceName(tests.TestBridgeName)
 
 			node, err := tests.AddBridgeOnSchedulableNode(clientset, tests.TestBridgeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -58,6 +65,56 @@ var _ = Describe("bridge-marker", func() {
 				return reported
 
 			}, 20*time.Second, 5*time.Second).Should(Equal(false))
+		})
+	})
+
+	Describe("pod requiring bridge resource", func() {
+		It("should be started only when bridge is available on node", func() {
+			resourceName := tests.GenerateResourceName(tests.TestPodBridgeName)
+			requiredResourceCount := "1"
+			requiredResources := corev1.ResourceList{
+				resourceName: resource.MustParse(requiredResourceCount),
+			}
+
+			podReq := tests.PodSpec(tests.TestPodName, requiredResources)
+			_, err := clientset.CoreV1().Pods(DefaultNamespace).Create(podReq)
+			Expect(err).ToNot(HaveOccurred())
+
+			tests.CheckPodStatus(
+				clientset, 60,
+				func(pod *corev1.Pod) bool {
+					return pod.Status.Phase == "Pending"
+				},
+			)
+
+			tests.CheckPodStatus(
+				clientset, 600,
+				func(pod *corev1.Pod) bool {
+					Expect(fmt.Sprint(pod.Status.Phase)).To(Equal("Pending"))
+					for _, condition := range pod.Status.Conditions {
+						if condition.Reason == "Unschedulable" {
+							return true
+						}
+					}
+					return false
+				},
+			)
+
+			node, err := tests.AddBridgeOnSchedulableNode(clientset, tests.TestPodBridgeName)
+			tests.CheckPodStatus(
+				clientset, 120,
+				func(pod *corev1.Pod) bool {
+					if pod.Status.Phase == "Running" {
+						Expect(pod.Spec.NodeName).To(Equal(node))
+						return true
+					}
+					return false
+				},
+			)
+
+			err = tests.RemoveBridgeFromNode(node, tests.TestPodBridgeName)
+			Expect(err).ToNot(HaveOccurred())
+			clientset.CoreV1().Pods(DefaultNamespace).Delete(tests.TestPodName, &v1.DeleteOptions{})
 		})
 	})
 })


### PR DESCRIPTION
This PR adds a func test adding a pod requiring a bridge resource.
This is marked by the following manifest section:
    resources:
      limits:
        bridge.network.kubevirt.io/br: 1
      requests:
        bridge.network.kubevirt.io/br: 1

When the pod is first added, the bridge resource does not exist yet, so the pod should be stuck in "Pending". Then when the bridge is created, the pod should move to "Runnning".