### PR TITLE
functest, Change KUBECONFIG to be configurable in functest

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,5 +25,6 @@ source hack/config.sh
 if [[ ${TARGET} == openshift* ]]; then
     oc=${kubectl}
 fi
+KUBECONFIG=${KUBECONFIG:-$(cluster/kubeconfig.sh)}
 export KUBEVIRT_PROVIDER=$KUBEVIRT_PROVIDER
-${TESTS_OUT_DIR}/tests.test -kubeconfig=$(cluster/kubeconfig.sh) ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${KUBECONFIG} ${FUNC_TEST_ARGS}


### PR DESCRIPTION
Currently, functests only use the repo's KUBECONFIG
configuration. This means that tests will run only
ion clusters generated by this repo.
Changed KUBECONFIG in hack/functest.sh to be
configurable.
This change will allow running the
functest as tier1 test in other repos' deploying
bridge marker, using their clusters.