### PR TITLE
DaemonSet, Add Priority class

### DIFF
--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -27,6 +27,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      priorityClassName: system-node-critical
       containers:
       - name: bridge-marker
         image: ${BRIDGE_MARKER_IMAGE_REPO}/${BRIDGE_MARKER_IMAGE_NAME}:${BRIDGE_MARKER_IMAGE_VERSION}


### PR DESCRIPTION
Add `system-node-critical` to bridge marker DaemonSet.
Since bridge marker pod should run on each node,
assign `system-node-critical` pc to it.
This will make the control plane less sensitive to preemption
than user workloads.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```