### PR TITLE
cluster, allow to override KUBEVIRTCI_TAG env var

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.19'}
-export KUBEVIRTCI_TAG="2011121336-c2cf403"
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-'2011121336-c2cf403'}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.


### PR DESCRIPTION
when running CNAO tier1 tests of bridge-marker, we may want
to use the KUBEVIRTCI_TAG of the repo running the test, and
not the current KUBEVIRTCI_TAG used on the local bridge-marker
repo.