### PR TITLE
Reduce net consumption

### DIFF
--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -24,7 +25,8 @@ import (
 
 func main() {
 	nodeName := flag.String("node-name", "", "name of kubernetes node")
-	pollInterval := flag.Int("poll-interval", 10, "interval between updates in seconds, 10 by default")
+	const defaultPollInterval = 60 * time.Second
+	pollInterval := flag.Int("update-interval", int(defaultPollInterval.Seconds()), fmt.Sprintf("interval between updates in seconds, %d by default", defaultPollInterval))
 
 	flag.Parse()
 

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -17,16 +17,22 @@ package main
 import (
 	"flag"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/kubevirt/bridge-marker/pkg/cache"
 	"github.com/kubevirt/bridge-marker/pkg/marker"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func main() {
 	nodeName := flag.String("node-name", "", "name of kubernetes node")
-	const defaultPollInterval = 60 * time.Second
-	pollInterval := flag.Int("update-interval", int(defaultPollInterval.Seconds()), fmt.Sprintf("interval between updates in seconds, %d by default", defaultPollInterval))
+	const defaultUpdateInterval = 60 * time.Second
+	updateInterval := flag.Int("update-interval", int(defaultUpdateInterval.Seconds()), fmt.Sprintf("interval between updates in seconds, %d by default", defaultUpdateInterval))
+
+	const defaultReconcileInterval = 10 * time.Minute
+	reconcileInterval := flag.Int("reconcile-interval", int(defaultReconcileInterval.Minutes()), fmt.Sprintf("interval between node bridges reconcile in minutes, %d by default", defaultReconcileInterval))
 
 	flag.Parse()
 
@@ -34,11 +40,26 @@ func main() {
 		glog.Fatal("node-name must be set")
 	}
 
-	for {
-		err := marker.Update(*nodeName)
+	cache := cache.Cache{}
+	wait.PollImmediateInfinite(time.Duration(*updateInterval)*time.Second, func() (bool, error) {
+		if time.Now().Sub(cache.LastRefreshTime()) >= time.Duration(*reconcileInterval)*time.Minute {
+			reportedBridges, err := marker.GetReportedResources(*nodeName)
+			if err != nil {
+				glog.Errorf("GetReportedResources failed: %v", err)
+			}
+
+			if !reflect.DeepEqual(cache.Bridges(), reportedBridges) {
+				glog.Warningf("cached bridges are different than the reported bridges on node %s", *nodeName)
+			}
+			
+			cache.Refresh(reportedBridges)
+		}
+
+		err := marker.Update(*nodeName, cache)
 		if err != nil {
 			glog.Errorf("Update failed: %v", err)
 		}
-		time.Sleep(time.Duration(*pollInterval) * time.Second)
-	}
+
+		return false, nil
+	})
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"time"
+)
+
+type Cache struct {
+	lastRefreshTime time.Time
+	bridges         map[string]bool
+}
+
+func (c *Cache) Refresh(freshBridges map[string]bool) {
+	c.bridges = freshBridges
+	c.lastRefreshTime = time.Now()
+}
+
+func (c *Cache) LastRefreshTime() time.Time {
+	return c.lastRefreshTime
+}
+
+func (c Cache) Bridges() map[string]bool {
+	bridgesCopy := make(map[string]bool)
+	for bridge, exist := range c.bridges {
+		bridgesCopy[bridge] = exist
+	}
+	return bridgesCopy
+}


### PR DESCRIPTION
As an attempt to reduce the bridge-marker net consumption this PR increases the timeouts between the updates and uses a cache to keep track of the already reported bridges on the node. Only every ten iterations the info will be retrieved from the actual node object.
Also to avoid communication peeks a jitter is used to randomize the interval between updates.

```release-note
use cache to keep track of the reported bridges, instead of retrieving it from the API server
```