### PR TITLE
Set max unavailable to 10%

### DIFF
--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       name: bridge-marker
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:


### PR DESCRIPTION
The default value of maxUnavailable is 1. That serializes upgrades and
may drag for very long time. This change turns it into 10% to speed up
the upgrade process while keeping services reasonably available.

https://bugzilla.redhat.com/show_bug.cgi?id=1990065

Signed-off-by: Petr Horáček <phoracek@redhat.com>