### PR TITLE
Pass cache as pointer

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -49,7 +49,7 @@ REGISTRY=$manifest_registry make manifests
 until [[ $(./cluster/kubectl.sh get --ignore-not-found -f $bridge_marker_manifest 2>&1 | wc -l) -eq 0 ]]; do sleep 1; done
 until [[ $(./cluster/kubectl.sh get --ignore-not-found ds bridge-marker 2>&1 | wc -l) -eq 0 ]]; do sleep 1; done
 
-./cluster/kubectl.sh create -f $bridge_marker_manifest
+sed 's/quay.io\/kubevirt/registry:5000/g' $bridge_marker_manifest | ./cluster/kubectl.sh create -f -
 
 # Wait for daemon set to be scheduled on all nodes
 timeout=300

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -40,24 +40,24 @@ func main() {
 		glog.Fatal("node-name must be set")
 	}
 
-	cache := cache.Cache{}
+	markerCache := cache.Cache{}
 	wait.JitterUntil(func() {
 		jitteredReconcileInterval := wait.Jitter(time.Duration(*reconcileInterval)*time.Minute, 1.2)
-		shouldReconcileNode := time.Now().Sub(cache.LastRefreshTime()) >= jitteredReconcileInterval
+		shouldReconcileNode := time.Now().Sub(markerCache.LastRefreshTime()) >= jitteredReconcileInterval
 		if shouldReconcileNode {
 			reportedBridges, err := marker.GetReportedResources(*nodeName)
 			if err != nil {
 				glog.Errorf("GetReportedResources failed: %v", err)
 			}
 
-			if !reflect.DeepEqual(cache.Bridges(), reportedBridges) {
+			if !reflect.DeepEqual(markerCache.Bridges(), reportedBridges) {
 				glog.Warningf("cached bridges are different than the reported bridges on node %s", *nodeName)
 			}
 
-			cache.Refresh(reportedBridges)
+			markerCache.Refresh(reportedBridges)
 		}
 
-		err := marker.Update(*nodeName, cache)
+		err := marker.Update(*nodeName, &markerCache)
 		if err != nil {
 			glog.Errorf("Update failed: %v", err)
 		}

--- a/pkg/marker/marker.go
+++ b/pkg/marker/marker.go
@@ -93,12 +93,12 @@ func GetReportedResources(nodeName string) (map[string]bool, error) {
 	return reportedResources, nil
 }
 
-func Update(nodeName string, cache cache.Cache) error {
+func Update(nodeName string, markerCache *cache.Cache) error {
 	availableResources, err := getAvailableResources()
 	if err != nil {
 		return fmt.Errorf("failed to list available resources: %v", err)
 	}
-	reportedResources := cache.Bridges()
+	reportedResources := markerCache.Bridges()
 	patchOperations := make([]patchOperation, 0)
 
 	for reportedResource, _ := range reportedResources {
@@ -137,6 +137,6 @@ func Update(nodeName string, cache cache.Cache) error {
 		return fmt.Errorf("failed to apply patch %s on node: %v", payloadBytes, err)
 	}
 
-	cache.Refresh(availableResources)
+	markerCache.Refresh(availableResources)
 	return nil
 }

--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -59,7 +59,7 @@ var _ = Describe("bridge-marker", func() {
 				}
 				capacityInt, _ := capacity.AsInt64()
 				return capacityInt, nil
-			}, 20*time.Second, 5*time.Second).Should(Equal(int64(1000)), fmt.Sprintf("should has node with capacity 1000 for the resource %s after adding the bridge to the node", resourceName))
+			}, 180*time.Second, 5*time.Second).Should(Equal(int64(1000)), fmt.Sprintf("should has node with capacity 1000 for the resource %s after adding the bridge to the node", resourceName))
 
 			err = tests.RemoveBridgeFromNode(node, tests.TestBridgeName)
 			Expect(err).ToNot(HaveOccurred())
@@ -68,7 +68,7 @@ var _ = Describe("bridge-marker", func() {
 				node, err := clientset.CoreV1().Nodes().Get(context.TODO(), node, v1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return node.Status.Capacity
-			}, 20*time.Second, 5*time.Second).ShouldNot(HaveKey(resourceName), fmt.Sprintf("should no has no capacity at node for resource %s after removing the bridge", resourceName))
+			}, 180*time.Second, 5*time.Second).ShouldNot(HaveKey(resourceName), fmt.Sprintf("should no has no capacity at node for resource %s after removing the bridge", resourceName))
 		})
 	})
 


### PR DESCRIPTION
fixed the bug created by https://github.com/kubevirt/bridge-marker/pull/35 
by changing the cache to be passed as pointer and update the tests according to the updates interval.

Also this PR makes the bridge-marker image to be pulled from the registry and not from quay