### PR TITLE
cluster-sync: pull image from registry

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -49,7 +49,7 @@ REGISTRY=$manifest_registry make manifests
 until [[ $(./cluster/kubectl.sh get --ignore-not-found -f $bridge_marker_manifest 2>&1 | wc -l) -eq 0 ]]; do sleep 1; done
 until [[ $(./cluster/kubectl.sh get --ignore-not-found ds bridge-marker 2>&1 | wc -l) -eq 0 ]]; do sleep 1; done
 
-./cluster/kubectl.sh create -f $bridge_marker_manifest
+sed 's/quay.io\/kubevirt/registry:5000/g' $bridge_marker_manifest | ./cluster/kubectl.sh create -f -
 
 # Wait for daemon set to be scheduled on all nodes
 timeout=300


### PR DESCRIPTION
When making changes locally, and running `make cluster-sync` the changes did
not take place because the image for the marker pod was pulled from quay.
This commit makes it take it from the local registry.

This is a backport of a patch from the main branch.

Signed-off-by: alonsadan <asadan@redhat.com>
Signed-off-by: Petr Horáček <phoracek@redhat.com>