### PR TITLE
tests, marker-test: increase timeout

### DIFF
--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -110,7 +110,7 @@ var _ = Describe("bridge-marker", func() {
 
 			node, err := tests.AddBridgeOnSchedulableNode(clientset, tests.TestPodBridgeName)
 			tests.CheckPodStatus(
-				clientset, 120,
+				clientset, 240,
 				func(pod *corev1.Pod) bool {
 					if pod.Status.Phase == "Running" {
 						Expect(pod.Spec.NodeName).To(Equal(node))


### PR DESCRIPTION
Recently the update interval of the node  was increased to 1 minute, and also a jitter
with 1.2 factor was added. This means that if for some reason one update was missed,
in the worst-case scenario there could be almost 2 minutes and a half difference between updates.

This could  makes the 120 interval not enough for the a pod to turn from Pending to Running
based on the label added to the node.

Therefor this commit increases the timeout for 240 seconds which should be enough for
the label to appear on the node and for the pod to become ready.

Signed-off-by: alonsadan <asadan@redhat.com>