### PR TITLE
[release-0.9.1] Add nodeSelector for Linux os (#44)

### DIFF
--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -26,7 +26,8 @@ spec:
       serviceAccountName: bridge-marker
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
In order to make sure that bridge-marker can be used
in mixed node environment I added Linux OS nodeSelector