### PR TITLE
Add github issue/PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Thanks for sending a pull request!
+
+Before you click the 'Create pull request' make sure that:
+- This PR introduces a single feature of fix, just one
+- This PR does not leave the main branch broken
+- Every commit in this PR has a commit message explaining what do you change,
+  why and what is the outcome
+- If your change introduces a complex concept or a change to user interaction
+  with the project or the application, make sure to document it
+
+If you don't comply with these rules, you waste your energy, time of reviewers
+and cause suffering of future generations.
+-->
+
+**What this PR does / why we need it**:
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
+3. If no release note is required, just write "NONE".
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
Similar to other kubevirt projects they include the release_note field
at the PR making easier to modify it.

```release-note
None
```