### PR TITLE
manifests: Remove arch label

### DIFF
--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -26,7 +26,6 @@ spec:
       serviceAccountName: bridge-marker
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       tolerations:
       - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Removing kubernetes.io/arch will unblock running on ARM. Note: U/S was not tested on ARM.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
