### PR TITLE
Update container image in PodSpec to use centos:10

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -136,7 +136,7 @@ func PodSpec(name string, resourceRequirements v1.ResourceList) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  name,
-					Image: "centos",
+					Image: "centos:10",
 					Resources: v1.ResourceRequirements{
 						Limits:   resourceRequirements,
 						Requests: resourceRequirements,


### PR DESCRIPTION
Changed the container image from "centos" to "centos:10" in the PodSpec function to specify a more specific version of the CentOS image.

**What this PR does / why we need it**:
We encountered the following test failure while running the Bridge Marker E2E tests from CNAO:

**Failure Summary:**

```
[Fail] bridge-marker pod requiring bridge resource [It] should be started only when bridge is available on node 
/tmp/deploy.bridge-marker.oy9U/github.com/kubevirt/bridge-marker/tests/utils.go:157

Ran 2 of 2 Specs in 453.936 seconds
FAIL! -- 1 Passed | 1 Failed | 0 Pending | 0 Skipped
```

The pod created here(https://github.com/kubevirt/bridge-marker/blob/5fb005a5aa5e2d9d5bec2814e680545d3ad67332/tests/marker_test.go#L88) in this test (`bridge-marker-test`) encountered an `ErrImagePull` issue. The pod status was:

```
NAME                             READY   STATUS         RESTARTS   AGE
bridge-marker-test               0/1     ErrImagePull   0          118s
```

Upon examining the pod's describe output, we found the following error:

```
state:
      waiting:
        message: 'reading manifest latest in quay.io/centos: StatusCode: 404, "<!doctype html>\n<html lang=en>\n<title>404 Not Foun..."'
        reason: ErrImagePull
```

The issue is caused by the Kubernetes node attempting to pull the `centos:latest` image from the registry, which results in a `404 Not Found` error.

**Solution:**
To resolve this issue, we will update the image to use a specific tag instead of the default `centos` image.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
None
```
