### PR TITLE
Update container image in PodSpec to use ubuntu

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -136,7 +136,7 @@ func PodSpec(name string, resourceRequirements v1.ResourceList) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  name,
-					Image: "centos:10",
+					Image: "ubuntu",
 					Resources: v1.ResourceRequirements{
 						Limits:   resourceRequirements,
 						Requests: resourceRequirements,


### PR DESCRIPTION
Changed the container image from "centos" to "ubuntu" in the PodSpec function to specify a more specific version of the CentOS image.


**What this PR does / why we need it**:

We are encountering an unusual issue with accessing the CentOS image. More details at: https://github.com/kubevirt/cluster-network-addons-operator/pull/2179

Since this test is not dependent on any specific image, we would like to switch from CentOS to Ubuntu in order to get the bridge marker test lane to pass.

For now, we will proceed with the Ubuntu image, which is 73.8 MB in size.

Meanwhile, we can investigate the issue with accessing the CentOS image in parallel.


**Special notes for your reviewer**:

**Release note**:


```release-note
None
```
