### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -48,6 +48,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+        terminationMessagePolicy: FallbackToLogsOnError
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:
set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
