### PR TITLE
cluster: Fix kubevirtci clone storm

### DIFF
--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -15,22 +15,16 @@
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.34'}
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2509181951-8264c60a}
 
-KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 # The CLUSTER_PATH var is used in cluster folder and points to the _kubevirtci where the cluster is deployed from.
 CLUSTER_PATH=${CLUSTER_PATH:-"${PWD}/_kubevirtci/"}
-
-function cluster::_get_repo() {
-    git --git-dir ${CLUSTER_PATH}/.git remote get-url origin
-}
 
 function cluster::_get_tag() {
     git --git-dir ${CLUSTER_PATH}/.git describe --tags
 }
 
 function cluster::install() {
-    # Remove cloned kubevirtci repository if it does not match the requested one
     if [ -d ${CLUSTER_PATH} ]; then
-        if [ $(cluster::_get_repo) != ${KUBEVIRTCI_REPO} -o $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
+        if [[ $(cluster::_get_tag) != ${KUBEVIRTCI_TAG} ]]; then
             rm -rf ${CLUSTER_PATH}
         fi
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:

`cluster::install` checks whether the existing kubevirtci clone matches the requested one by comparing both the remote URL and the tag. 
The remote URL check fails when the clone was done via SSH (`git@github.com:...`) because the stored `KUBEVIRTCI_REPO` uses HTTPS (`https://github.com/...`). 
The mismatch causes kubevirtci to be deleted and re-cloned on every invocation, wiping the cluster kubeconfig and breaking the dev workflow.

Remove the remote URL check and keep only the tag comparison.

Derived from: https://github.com/kubevirt/cluster-network-addons-operator/pull/2619

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```