### PR TITLE
Make health probe port configurable

### DIFF
--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -37,7 +37,9 @@ func main() {
 
 	const defaultHealthProbePort = 8081
 	healthProbePort := flag.Int("health-probe-port", defaultHealthProbePort, fmt.Sprintf("port for the health probe HTTP server, %d by default", defaultHealthProbePort))
-	healthProbePath := flag.String("health-probe-path", "/healthz", "HTTP path for the health probe endpoint")
+	if *healthProbePort < 1 || *healthProbePort > 65535 {
+		glog.Fatalf("health-probe-port must be between 1 and 65535, got %d", *healthProbePort)
+	}
 
 	flag.Parse()
 
@@ -71,12 +73,12 @@ func main() {
 
 	}()
 
-	http.HandleFunc(*healthProbePath, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
 	})
 	addr := fmt.Sprintf(":%d", *healthProbePort)
-	glog.Infof("Starting health probe server on %s%s", addr, *healthProbePath)
+	glog.Infof("Starting health probe server on %s/healthz", addr)
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		glog.Fatalf("Health probe server failed: %v", err)
 	}

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -35,6 +35,10 @@ func main() {
 	const defaultReconcileInterval = 10 * time.Minute
 	reconcileInterval := flag.Int("reconcile-interval", int(defaultReconcileInterval.Minutes()), fmt.Sprintf("interval between node bridges reconcile in minutes, %d by default", defaultReconcileInterval))
 
+	const defaultHealthProbePort = 8081
+	healthProbePort := flag.Int("health-probe-port", defaultHealthProbePort, fmt.Sprintf("port for the health probe HTTP server, %d by default", defaultHealthProbePort))
+	healthProbePath := flag.String("health-probe-path", "/healthz", "HTTP path for the health probe endpoint")
+
 	flag.Parse()
 
 	if *nodeName == "" {
@@ -67,12 +71,13 @@ func main() {
 
 	}()
 
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(*healthProbePath, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
 	})
-	glog.Infof("Starting health probe server on :8081")
-	if err := http.ListenAndServe(":8081", nil); err != nil {
+	addr := fmt.Sprintf(":%d", *healthProbePort)
+	glog.Infof("Starting health probe server on %s%s", addr, *healthProbePath)
+	if err := http.ListenAndServe(addr, nil); err != nil {
 		glog.Fatalf("Health probe server failed: %v", err)
 	}
 }

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -37,14 +37,15 @@ func main() {
 
 	const defaultHealthProbePort = 8081
 	healthProbePort := flag.Int("health-probe-port", defaultHealthProbePort, fmt.Sprintf("port for the health probe HTTP server, %d by default", defaultHealthProbePort))
-	if *healthProbePort < 1 || *healthProbePort > 65535 {
-		glog.Fatalf("health-probe-port must be between 1 and 65535, got %d", *healthProbePort)
-	}
 
 	flag.Parse()
 
 	if *nodeName == "" {
 		glog.Fatal("node-name must be set")
+	}
+
+	if *healthProbePort < 1 || *healthProbePort > 65535 {
+		glog.Fatalf("health-probe-port must be between 1 and 65535, got %d", *healthProbePort)
 	}
 
 	go func() {

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -25,7 +25,6 @@ bridge_marker_image_version=${BRIDGE_MARKER_IMAGE_VERSION:-latest}
 bridge_marker_image_pull_policy=${BRIDGE_MARKER_IMAGE_PULL_POLICY:-IfNotPresent}
 
 health_probe_port=${HEALTH_PROBE_PORT:-8081}
-health_probe_path=${HEALTH_PROBE_PATH:-/healthz}
 
 mkdir -p examples
 for template in manifests/*.in; do
@@ -37,6 +36,5 @@ for template in manifests/*.in; do
         -e "s#\${BRIDGE_MARKER_IMAGE_VERSION}#${bridge_marker_image_version}#g" \
         -e "s#\${BRIDGE_MARKER_IMAGE_PULL_POLICY}#${bridge_marker_image_pull_policy}#g" \
         -e "s#\${HEALTH_PROBE_PORT}#${health_probe_port}#g" \
-        -e "s#\${HEALTH_PROBE_PATH}#${health_probe_path}#g" \
         ${template} > examples/${name}
 done

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -24,6 +24,9 @@ bridge_marker_image_name=${BRIDGE_MARKER_IMAGE_NAME:-bridge-marker}
 bridge_marker_image_version=${BRIDGE_MARKER_IMAGE_VERSION:-latest}
 bridge_marker_image_pull_policy=${BRIDGE_MARKER_IMAGE_PULL_POLICY:-IfNotPresent}
 
+health_probe_port=${HEALTH_PROBE_PORT:-8081}
+health_probe_path=${HEALTH_PROBE_PATH:-/healthz}
+
 mkdir -p examples
 for template in manifests/*.in; do
     name=$(basename ${template%.in})
@@ -33,5 +36,7 @@ for template in manifests/*.in; do
         -e "s#\${BRIDGE_MARKER_IMAGE_NAME}#${bridge_marker_image_name}#g" \
         -e "s#\${BRIDGE_MARKER_IMAGE_VERSION}#${bridge_marker_image_version}#g" \
         -e "s#\${BRIDGE_MARKER_IMAGE_PULL_POLICY}#${bridge_marker_image_pull_policy}#g" \
+        -e "s#\${HEALTH_PROBE_PORT}#${health_probe_port}#g" \
+        -e "s#\${HEALTH_PROBE_PATH}#${health_probe_path}#g" \
         ${template} > examples/${name}
 done

--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -41,8 +41,6 @@ spec:
           - $(NODE_NAME)
           - -health-probe-port
           - "${HEALTH_PROBE_PORT}"
-          - -health-probe-path
-          - "${HEALTH_PROBE_PATH}"
         resources:
           requests:
             cpu: "10m"
@@ -59,13 +57,13 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:
-            path: ${HEALTH_PROBE_PATH}
+            path: /healthz
             port: healthport
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: ${HEALTH_PROBE_PATH}
+            path: /healthz
             port: healthport
           initialDelaySeconds: 10
           periodSeconds: 20

--- a/manifests/bridge-marker.yml.in
+++ b/manifests/bridge-marker.yml.in
@@ -39,6 +39,10 @@ spec:
         args:
           - -node-name
           - $(NODE_NAME)
+          - -health-probe-port
+          - "${HEALTH_PROBE_PORT}"
+          - -health-probe-path
+          - "${HEALTH_PROBE_PATH}"
         resources:
           requests:
             cpu: "10m"
@@ -50,18 +54,18 @@ spec:
                 fieldPath: spec.nodeName
         ports:
         - name: healthport
-          containerPort: 8081
+          containerPort: ${HEALTH_PROBE_PORT}
           protocol: TCP
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: ${HEALTH_PROBE_PATH}
             port: healthport
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: ${HEALTH_PROBE_PATH}
             port: healthport
           initialDelaySeconds: 10
           periodSeconds: 20


### PR DESCRIPTION
Allow to set healthProbePort/healthProbePath via cmd args. 

Default value 8081 is used if undefined.

Made with Cursor

Fixes: #101 
